### PR TITLE
Removed Delay Between movement, Added delay between pokemon catches, CatchWhileWalking Fix

### DIFF
--- a/PokemonGo.RocketAPI.Console/App.config
+++ b/PokemonGo.RocketAPI.Console/App.config
@@ -55,7 +55,7 @@
       <setting name="TransferDuplicatePokemon" serializeAs="String">
         <value>True</value>
       </setting>
-      <setting name="DelayBetweenMove" serializeAs="String">
+      <setting name="DelayBetweenPokemonCatch" serializeAs="String">
         <value>5000</value>
       </setting>
       <setting name="UsePokemonToNotCatchFilter" serializeAs="String">

--- a/PokemonGo.RocketAPI.Console/Settings.cs
+++ b/PokemonGo.RocketAPI.Console/Settings.cs
@@ -26,7 +26,7 @@ namespace PokemonGo.RocketAPI.Console
         public double WalkingSpeedInKilometerPerHour => UserSettings.Default.WalkingSpeedInKilometerPerHour;
         public bool EvolveAllPokemonWithEnoughCandy => UserSettings.Default.EvolveAllPokemonWithEnoughCandy;
         public bool TransferDuplicatePokemon => UserSettings.Default.TransferDuplicatePokemon;
-        public int DelayBetweenMove => UserSettings.Default.DelayBetweenMove;
+        public int DelayBetweenPokemonCatch => UserSettings.Default.DelayBetweenPokemonCatch;
         public bool UsePokemonToNotCatchFilter => UserSettings.Default.UsePokemonToNotCatchFilter;
 
         public string GoogleRefreshToken

--- a/PokemonGo.RocketAPI.Console/UserSettings.Designer.cs
+++ b/PokemonGo.RocketAPI.Console/UserSettings.Designer.cs
@@ -170,12 +170,12 @@ namespace PokemonGo.RocketAPI.Console {
         [global::System.Configuration.UserScopedSettingAttribute()]
         [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
         [global::System.Configuration.DefaultSettingValueAttribute("5000")]
-        public int DelayBetweenMove {
+        public int DelayBetweenPokemonCatch {
             get {
-                return ((int)(this["DelayBetweenMove"]));
+                return ((int)(this["DelayBetweenPokemonCatch"]));
             }
             set {
-                this["DelayBetweenMove"] = value;
+                this["DelayBetweenPokemonCatch"] = value;
             }
         }
         

--- a/PokemonGo.RocketAPI.Console/UserSettings.settings
+++ b/PokemonGo.RocketAPI.Console/UserSettings.settings
@@ -38,7 +38,7 @@
     <Setting Name="TransferDuplicatePokemon" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">True</Value>
     </Setting>
-    <Setting Name="DelayBetweenMove" Type="System.Int32" Scope="User">
+    <Setting Name="DelayBetweenPokemonCatch" Type="System.Int32" Scope="User">
       <Value Profile="(Default)">5000</Value>
     </Setting>
     <Setting Name="UsePokemonToNotCatchFilter" Type="System.Boolean" Scope="User">

--- a/PokemonGo.RocketAPI.Logic/Logic.cs
+++ b/PokemonGo.RocketAPI.Logic/Logic.cs
@@ -298,7 +298,6 @@ namespace PokemonGo.RocketAPI.Logic
                     Logger.Write($"Encounter problem: {encounter.Status}");
                 if (pokemons.ElementAtOrDefault(pokemons.Count() - 1) != pokemon) // If pokemon is not last pokemon in list, create delay between catches, else keep moving.
                 {
-                    Logger.Write("There's more pokemon here",LogLevel.Info);
                     await Task.Delay(_clientSettings.DelayBetweenPokemonCatch);
                 }
 

--- a/PokemonGo.RocketAPI.Logic/Logic.cs
+++ b/PokemonGo.RocketAPI.Logic/Logic.cs
@@ -266,7 +266,7 @@ namespace PokemonGo.RocketAPI.Logic
 
         private async Task ExecuteCatchAllNearbyPokemons()
         {
-            Logger.Write("Looking for pokemon..");
+            Logger.Write("Looking for pokemon..", LogLevel.Debug);
             var mapObjects = await _client.GetMapObjects();
 
             var pokemons =

--- a/PokemonGo.RocketAPI.Logic/Logic.cs
+++ b/PokemonGo.RocketAPI.Logic/Logic.cs
@@ -266,6 +266,7 @@ namespace PokemonGo.RocketAPI.Logic
 
         private async Task ExecuteCatchAllNearbyPokemons()
         {
+            Logger.Write("Looking for pokemon..");
             var mapObjects = await _client.GetMapObjects();
 
             var pokemons =

--- a/PokemonGo.RocketAPI.Logic/Logic.cs
+++ b/PokemonGo.RocketAPI.Logic/Logic.cs
@@ -79,7 +79,7 @@ namespace PokemonGo.RocketAPI.Logic
             {
                 var xpDifference = GetXPDiff(playerStat.Level);
                 var message =
-                    $"{playerName} | Level {playerStat.Level}: {playerStat.Experience - playerStat.PrevLevelXp - xpDifference}/{playerStat.NextLevelXp - playerStat.PrevLevelXp - xpDifference}XP";
+                     $"{playerName} | Level {playerStat.Level}: {playerStat.Experience - playerStat.PrevLevelXp - xpDifference}/{playerStat.NextLevelXp - playerStat.PrevLevelXp - xpDifference}XP";
                 Console.Title = message;
                 if (updateOnly == false)
                     Logger.Write(message);
@@ -296,9 +296,15 @@ namespace PokemonGo.RocketAPI.Logic
                     await CatchEncounter(encounter, pokemon);
                 else
                     Logger.Write($"Encounter problem: {encounter.Status}");
+                if (pokemons.ElementAtOrDefault(pokemons.Count() - 1) != pokemon) // If pokemon is not last pokemon in list, create delay between catches, else keep moving.
+                {
+                    Logger.Write("There's more pokemon here",LogLevel.Info);
+                    await Task.Delay(_clientSettings.DelayBetweenPokemonCatch);
+                }
+
             }
 
-            await Task.Delay(_clientSettings.DelayBetweenMove);
+
         }
 
 
@@ -341,7 +347,6 @@ namespace PokemonGo.RocketAPI.Logic
 
                 await Task.Delay(1000);
                 await RecycleItems();
-                await ExecuteCatchAllNearbyPokemons();
                 if (_clientSettings.TransferDuplicatePokemon) await TransferDuplicatePokemon();
             }
         }

--- a/PokemonGo.RocketAPI.Logic/Navigation.cs
+++ b/PokemonGo.RocketAPI.Logic/Navigation.cs
@@ -50,8 +50,6 @@ namespace PokemonGo.RocketAPI.Logic
                 await
                     _client.UpdatePlayerLocation(waypoint.Latitude, waypoint.Longitude, _client.Settings.DefaultAltitude);
 
-            if (functionExecutedWhileWalking != null)
-                await functionExecutedWhileWalking();
             do
             {
                 var millisecondsUntilGetUpdatePlayerLocationResponse =
@@ -79,6 +77,8 @@ namespace PokemonGo.RocketAPI.Logic
                     await
                         _client.UpdatePlayerLocation(waypoint.Latitude, waypoint.Longitude,
                             _client.Settings.DefaultAltitude);
+                if (functionExecutedWhileWalking != null) 
+                    await functionExecutedWhileWalking();// look for pokemon
                 await Task.Delay(Math.Min((int) (distanceToTarget/speedInMetersPerSecond*1000), 3000));
             } while (LocationUtils.CalculateDistanceInMeters(sourceLocation, targetLocation) >= 30);
 

--- a/PokemonGo.RocketAPI/ISettings.cs
+++ b/PokemonGo.RocketAPI/ISettings.cs
@@ -22,7 +22,7 @@ namespace PokemonGo.RocketAPI
         double WalkingSpeedInKilometerPerHour { get; }
         bool EvolveAllPokemonWithEnoughCandy { get; }
         bool TransferDuplicatePokemon { get; }
-        int DelayBetweenMove { get; }
+        int DelayBetweenPokemonCatch { get; }
         bool UsePokemonToNotCatchFilter { get; }
         ICollection<KeyValuePair<ItemId, int>> ItemRecycleFilter { get; }
 


### PR DESCRIPTION
Removed Delay Between movement. This delay was created as a delay between pokestop teleports, there is no need for this now since we have humanwalking.

Added Delay between pokemon catches, as setting, defaults to 5.

Removed unnecessary call to executecatchallnearbypokemon when a pokestop is reached. This already gets called by the humanwalking when we reach the pokestop.