### PR TITLE
Replaced hardcoded pokemon not to catch with text file list.

### DIFF
--- a/PokemonGo.RocketAPI.Console/Settings.cs
+++ b/PokemonGo.RocketAPI.Console/Settings.cs
@@ -13,8 +13,9 @@ namespace PokemonGo.RocketAPI.Console
     public class Settings : ISettings
     {
         private ICollection<PokemonId> _pokemonsNotToTransfer;
-
         private ICollection<PokemonId> _pokemonsToEvolve;
+        private ICollection<PokemonId> _pokemonsNotToCatch;
+
         public AuthType AuthType => (AuthType) Enum.Parse(typeof(AuthType), UserSettings.Default.AuthType, true);
         public string PtcUsername => UserSettings.Default.PtcUsername;
         public string PtcPassword => UserSettings.Default.PtcPassword;
@@ -95,12 +96,15 @@ namespace PokemonGo.RocketAPI.Console
         }
 
         //Do not catch those
-        public ICollection<PokemonId> PokemonsNotToCatch => new[]
+        public ICollection<PokemonId> PokemonsNotToCatch
         {
-            //Add pokemon here
-            PokemonId.Pidgey,
-            PokemonId.Rattata
-        };
+            get
+            {
+                //Type of pokemons not to catch
+                _pokemonsNotToCatch = _pokemonsNotToCatch ?? LoadPokemonList("Configs\\ConfigPokemonsNotToCatch.txt");
+                return _pokemonsNotToCatch;
+            }
+        }
 
         private static ICollection<PokemonId> LoadPokemonList(string filename)
         {


### PR DESCRIPTION
I'm not sure why it was hard coded not to catch pidgeys and rattatas, but now you can manage those settings from the "ConfigPokemonsNotToCatch.txt" file. Pidgey and rattata are no longer blocked.