### PR TITLE
Add back the playername to the window title

### DIFF
--- a/PokemonGo.RocketAPI.Logic/Logic.cs
+++ b/PokemonGo.RocketAPI.Logic/Logic.cs
@@ -404,6 +404,7 @@ namespace PokemonGo.RocketAPI.Logic
             while (true)
             {
                 _playerProfile = await _client.GetProfile();
+                _stats.SetUsername(_playerProfile);
                 if (_clientSettings.EvolveAllPokemonWithEnoughCandy)
                     await EvolveAllPokemonWithEnoughCandy(_clientSettings.PokemonsToEvolve);
                 if (_clientSettings.TransferDuplicatePokemon) await TransferDuplicatePokemon();

--- a/PokemonGo.RocketAPI.Logic/Utils/Statistics.cs
+++ b/PokemonGo.RocketAPI.Logic/Utils/Statistics.cs
@@ -3,6 +3,7 @@
 using System;
 using System.Linq;
 using System.Threading.Tasks;
+using PokemonGo.RocketAPI.GeneratedCode;
 
 #endregion
 
@@ -17,6 +18,7 @@ namespace PokemonGo.RocketAPI.Logic.Utils
         public static int TotalStardust;
         public static string CurrentLevelInfos;
         public static int Currentlevel = -1;
+        public static string PlayerName;
 
         public static DateTime InitSessionDateTime = DateTime.Now;
         public static TimeSpan Duration = DateTime.Now - InitSessionDateTime;
@@ -38,6 +40,10 @@ namespace PokemonGo.RocketAPI.Logic.Utils
             return output;
         }
 
+        public void SetUsername(GetPlayerResponse profile)
+        {
+            PlayerName = profile.Profile.Username ?? "";
+        }
         public static double _getSessionRuntime()
         {
             return (DateTime.Now - InitSessionDateTime).TotalSeconds/3600;
@@ -165,8 +171,8 @@ namespace PokemonGo.RocketAPI.Logic.Utils
         {
             return
                 string.Format(
-                    "Runtime {0} - Lvl: {1:0} | EXP/H: {2:0.0} | P/H: {3:0.0} | Stardust: {4:0} | Transfered: {5:0} | Items Recycled: {6:0}",
-                    _getSessionRuntimeInTimeFormat(), CurrentLevelInfos, TotalExperience/_getSessionRuntime(),
+                    "{0} - Runtime {1} - Lvl: {2:0} | EXP/H: {3:0.0} | P/H: {4:0.0} | Stardust: {5:0} | Transfered: {6:0} | Items Recycled: {7:0}",
+                    PlayerName, _getSessionRuntimeInTimeFormat(), CurrentLevelInfos, TotalExperience/_getSessionRuntime(),
                     TotalPokemons/_getSessionRuntime(), TotalStardust, TotalPokemonsTransfered, TotalItemsRemoved);
         }
 


### PR DESCRIPTION
The statistics 'improvement' removed the player title from the window so people running multiple bots at once can't tell which is which.