### PR TITLE
Fix "specified cast is not valid" error

### DIFF
--- a/PokemonGo.RocketAPI/GeneratedCode/Payloads.cs
+++ b/PokemonGo.RocketAPI/GeneratedCode/Payloads.cs
@@ -15591,7 +15591,7 @@ namespace PokemonGo.RocketAPI.GeneratedCode
         private long cooldownCompleteTimestampMs_;
         private int experienceAwarded_;
         private int gemsAwarded_;
-        private global::PokemonGo.RocketAPI.GeneratedCode.PokemonData pokemonDataEgg_;
+        private PokemonData pokemonDataEgg_;
         private global::PokemonGo.RocketAPI.GeneratedCode.FortSearchResponse.Types.Result result_ = 0;
 
         public FortSearchResponse()


### PR DESCRIPTION
When you go to a stop and would be awarded an egg (but happen to have a full basket of eggs), I would get a "specified cast is not valid" error and the bot aborts.

When I simplified this line (in Visual Studio it pointed out an error after tracking it down), it continues to run but no longer freezes.