### PR TITLE
Update ConfigPokemonsToKeep.txt

### DIFF
--- a/PokemonGo.RocketAPI.Console/Configs/ConfigPokemonsToKeep.txt
+++ b/PokemonGo.RocketAPI.Console/Configs/ConfigPokemonsToKeep.txt
@@ -1,7 +1,18 @@
-Dragonite
+Venusaur
 Charizard
-Zapdos
+Blastoise
+Alakazam
+Farfetch'd
+Kangaskhan
+Mr. Mime
+Lapras
+Ditto
+Porygon
+Aerodactyl
 Snorlax
-Alakhazam
-Mew
+Articuno
+Zapdos
+Moltres
+Dragonite
 Mewtwo
+Mew


### PR DESCRIPTION
Made a typo in the previous pull request.

`Blastoise` was misspelled as `Blastiose`

Fixed now.